### PR TITLE
Update Search-Protection Pendaftaran Cron Job Baru

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ Klik Save Changes.
 
 ## Changelog
 
+### 1.3.1  (28 Juli 2025)
+
+* **Perbaikan Bug:** Memperbaiki bug kritis di mana semua pengaturan plugin bisa terhapus setelah 24 jam. Masalah ini disebabkan oleh konflik nama pada tugas terjadwal (cron job) yang digunakan untuk membersihkan log. Nama cron job telah diubah menjadi lebih spesifik untuk mencegah konflik dengan plugin lain dan memastikan hanya data log yang dihapus.
+* **Peningkatan:** Proses aktivasi plugin kini secara otomatis menghapus jadwal cron lama (jika ada) untuk memastikan transisi yang mulus saat memperbarui plugin.
+
 ### 1.3.0 (22 Juli 2025)
 * **Fitur Baru:** Menambahkan fungsionalitas untuk mencadangkan (ekspor) dan memulihkan (impor) seluruh pengaturan plugin.
 * **Fitur Baru:** Menambahkan opsi di halaman pengaturan untuk secara otomatis menghapus semua data saat plugin dihapus.

--- a/readme.txt
+++ b/readme.txt
@@ -42,6 +42,12 @@ Tidak. Plugin ini sangat ringan. Proses pemblokiran terjadi di sisi server sebel
 
 == Changelog ==
 
+= 1.3.1 (28 Juli 2025) =
+
+PERBAIKAN: Memperbaiki bug kritis di mana semua pengaturan plugin bisa terhapus setelah 24 jam. Masalah ini disebabkan oleh konflik nama pada tugas terjadwal (cron job) yang digunakan untuk membersihkan log. Nama cron job telah diubah menjadi lebih spesifik untuk mencegah konflik dengan plugin lain dan memastikan hanya data log yang dihapus.
+
+PENINGKATAN: Proses aktivasi plugin kini secara otomatis menghapus jadwal cron lama (jika ada) untuk memastikan transisi yang mulus saat memperbarui plugin.
+
 = 1.3.0 =
 * FITUR: Menambahkan opsi untuk menghapus semua data plugin (pengaturan dan log) saat plugin di-uninstall.
 * FITUR: Menambahkan fungsionalitas untuk mencadangkan (ekspor) dan memulihkan (impor) semua pengaturan plugin.


### PR DESCRIPTION
Ringkasan Perubahan:

Nama Cron Job Diubah: Nama tugas terjadwal diubah dari telu_daily_log_cleanup_event menjadi telu_sp_daily_log_cleanup_event agar lebih unik.

Pembersihan Cron Job Lama: Skrip sekarang akan secara otomatis menghapus tugas terjadwal dengan nama lama saat plugin diaktifkan/diperbarui.

Pendaftaran Cron Job Baru: Tugas terjadwal dengan nama baru yang lebih spesifik akan didaftarkan.

Versi Plugin: Versi plugin saya naikkan menjadi 1.3.1 untuk menandakan adanya perbaikan ini.