### PR TITLE
Update Search-Protection.php

### DIFF
--- a/Search-Protection.php
+++ b/Search-Protection.php
@@ -3,7 +3,7 @@
  * Plugin Name: Search Protection
  * Plugin URI: https://github.com/hilfans/search-protection-wordpress
  * Description: Lindungi form pencarian dari spam dan karakter berbahaya dengan daftar hitam dan reCAPTCHA v3.
- * Version: 1.4.1
+ * Version: 1.4.2
  * Requires at least: 5.0
  * Requires PHP: 7.2
  * Author: <a href="https://msp.web.id" target="_blank">Hilfan</a>
@@ -19,19 +19,14 @@ class Search_Protect_Protection {
     private $option_name = 'search_protect_settings';
     private $log_table;
     private $cron_hook_name = 'search_protect_daily_log_cleanup';
-    private $plugin_version;
+    private $plugin_version = '1.4.2'; // Default version
 
     public function __construct() {
         global $wpdb;
         $this->log_table = $wpdb->prefix . 'search_protect_logs';
         
-        if ( ! function_exists( 'get_plugin_data' ) ) {
-            require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-        }
-        $plugin_data = get_plugin_data( __FILE__ );
-        $this->plugin_version = $plugin_data['Version'];
-
         // Main Hooks
+        add_action('plugins_loaded', [$this, 'setup_plugin']);
         add_action('admin_menu', [$this, 'add_settings_page']);
         add_action('admin_init', [$this, 'register_settings']);
         add_action('pre_get_posts', [$this, 'intercept_search_query']);
@@ -44,6 +39,17 @@ class Search_Protect_Protection {
         register_activation_hook(__FILE__, [$this, 'activate']);
         register_deactivation_hook(__FILE__, [$this, 'deactivate']);
         add_action($this->cron_hook_name, [$this, 'do_daily_log_cleanup']);
+    }
+
+    /**
+     * Setup plugin properties that might trigger early translation.
+     */
+    public function setup_plugin() {
+        if ( ! function_exists( 'get_plugin_data' ) ) {
+            require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+        }
+        $plugin_data = get_plugin_data( __FILE__ );
+        $this->plugin_version = $plugin_data['Version'];
     }
 
     public function activate() {

--- a/readme.txt
+++ b/readme.txt
@@ -44,6 +44,13 @@ Tidak. Plugin ini sangat ringan. Proses pemblokiran terjadi di sisi server sebel
 
 == Changelog ==
 
+= 1.4.1 (22 Agustus 2025) =
+* PENINGKATAN KEPATUHAN: Mengubah semua prefix internal plugin (misalnya `sph_`) menjadi `search_protect_` untuk memenuhi persyaratan keunikan dan panjang minimal dari WordPress.org.
+* PENINGKATAN KEAMANAN: Mengganti fungsi `echo json_encode` dengan `wp_send_json` untuk proses ekspor pengaturan yang lebih aman dan sesuai standar WordPress.
+* PENINGKATAN KEAMANAN: Menambahkan sanitasi eksplisit pada nama file yang diunggah saat proses impor pengaturan.
+* DOKUMENTASI: Menambahkan bagian "Layanan Eksternal" pada file readme untuk menjelaskan penggunaan API Google reCAPTCHA sesuai pedoman.
+* CATATAN PENTING: Karena perubahan prefix internal yang signifikan, semua pengaturan plugin akan direset setelah melakukan update ke versi ini. Harap lakukan konfigurasi ulang atau pulihkan dari cadangan.
+
 = 1.4.0 (12 Agustus 2025) =
 * FITUR: Menambahkan opsi di halaman pengaturan untuk mengaktifkan atau menonaktifkan penghapusan log otomatis setiap 24 jam.
 * PENINGKATAN: Menghapus semua nama dan prefix yang berasosiasi dengan institusi (`TelU`, `telu_`) dan menggantinya dengan prefix unik (`SPH`, `sph_`) untuk mematuhi pedoman WordPress.org.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: hilfans0
 Tags: search, security, block, spam, protection
 Requires at least: 5.0
 Tested up to: 6.8
-Stable tag: 1.4.0
+Stable tag: 1.4.1
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -36,13 +36,13 @@ Ya, jika Anda ingin mengaktifkan fitur reCAPTCHA v3. Anda bisa mendapatkannya se
 
 Tidak. Plugin ini sangat ringan. Proses pemblokiran terjadi di sisi server sebelum WordPress menjalankan kueri pencarian yang berat ke database. Pembersihan log juga dijadwalkan dengan Cron Job agar tidak membebani server.
 
-== External Services ==
+== Layanan Eksternal ==
 
-This plugin integrates with the Google reCAPTCHA v3 service to protect search forms from spam and malicious bots. This feature is optional and can be enabled or disabled from the plugin's settings page.
+Plugin ini terintegrasi dengan layanan Google reCAPTCHA v3 untuk melindungi form pencarian dari spam dan bot berbahaya. Fitur ini bersifat opsional dan dapat diaktifkan atau dinonaktifkan dari halaman pengaturan plugin.
 
-* **Service:** Google reCAPTCHA v3
-* **What Data is Sent:** When a user submits a search form and the reCAPTCHA feature is enabled, the user's IP address and a reCAPTCHA token are sent to Google's servers for verification.
-* **Service's Terms and Policies:** For more information, please review Google's [Terms of Service](https://policies.google.com/terms) and [Privacy Policy](https://policies.google.com/privacy).
+* **Layanan:** Google reCAPTCHA v3
+* **Data yang Dikirim:** Saat pengguna mengirimkan form pencarian dan fitur reCAPTCHA diaktifkan, alamat IP pengguna dan token reCAPTCHA akan dikirim ke server Google untuk diverifikasi.
+* **Syarat dan Kebijakan Layanan:** Untuk informasi lebih lanjut, silakan tinjau [Persyaratan Layanan](https://policies.google.com/terms) dan [Kebijakan Privasi](https://policies.google.com/privacy) dari Google.
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,14 @@ Ya, jika Anda ingin mengaktifkan fitur reCAPTCHA v3. Anda bisa mendapatkannya se
 
 Tidak. Plugin ini sangat ringan. Proses pemblokiran terjadi di sisi server sebelum WordPress menjalankan kueri pencarian yang berat ke database. Pembersihan log juga dijadwalkan dengan Cron Job agar tidak membebani server.
 
+== External Services ==
+
+This plugin integrates with the Google reCAPTCHA v3 service to protect search forms from spam and malicious bots. This feature is optional and can be enabled or disabled from the plugin's settings page.
+
+* **Service:** Google reCAPTCHA v3
+* **What Data is Sent:** When a user submits a search form and the reCAPTCHA feature is enabled, the user's IP address and a reCAPTCHA token are sent to Google's servers for verification.
+* **Service's Terms and Policies:** For more information, please review Google's [Terms of Service](https://policies.google.com/terms) and [Privacy Policy](https://policies.google.com/privacy).
+
 == Screenshots ==
 
 1.  Halaman pengaturan utama untuk Pengaturan reCAPTCHA v3, Pengaturan Pemblokiran Kata.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors: hilfans0
 Tags: search, security, block, spam, protection
 Requires at least: 5.0
 Tested up to: 6.8
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -51,6 +51,9 @@ Plugin ini terintegrasi dengan layanan Google reCAPTCHA v3 untuk melindungi form
 3.  Menu pengaturan utama untuk Cadangkan & Pulihkan Pengaturan. 
 
 == Changelog ==
+
+= 1.4.2 (22 Agustus 2025) =
+* PERBAIKAN: Memperbaiki notifikasi debug `Translation loading... triggered too early` dengan menunda inisialisasi versi plugin ke hook `plugins_loaded`. Ini memastikan kompatibilitas dengan WordPress versi terbaru dan praktik terbaik pemuatan terjemahan.
 
 = 1.4.1 (22 Agustus 2025) =
 * PENINGKATAN KEPATUHAN: Mengubah semua prefix internal plugin (misalnya `sph_`) menjadi `search_protect_` untuk memenuhi persyaratan keunikan dan panjang minimal dari WordPress.org.

--- a/uninstall.php
+++ b/uninstall.php
@@ -11,7 +11,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
     exit;
 }
 
-$option_name = 'sph_settings';
+$option_name = 'search_protect_settings';
 $settings    = get_option( $option_name );
 
 // Check if the user has opted in to delete data on uninstall.
@@ -22,7 +22,7 @@ if ( ! empty( $settings['delete_on_uninstall'] ) && '1' === $settings['delete_on
 
     // Drop the custom database log table.
     global $wpdb;
-    $log_table = $wpdb->prefix . 'sph_logs';
+    $log_table = $wpdb->prefix . 'search_protect_logs';
     // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching
     $wpdb->query( "DROP TABLE IF EXISTS {$log_table}" );
 }


### PR DESCRIPTION
= 1.4.1 (22 Agustus 2025) =
* PENINGKATAN KEPATUHAN: Mengubah semua prefix internal plugin (misalnya `sph_`) menjadi `search_protect_` untuk memenuhi persyaratan keunikan dan panjang minimal dari WordPress.org.
* PENINGKATAN KEAMANAN: Mengganti fungsi `echo json_encode` dengan `wp_send_json` untuk proses ekspor pengaturan yang lebih aman dan sesuai standar WordPress.
* PENINGKATAN KEAMANAN: Menambahkan sanitasi eksplisit pada nama file yang diunggah saat proses impor pengaturan.
* DOKUMENTASI: Menambahkan bagian "Layanan Eksternal" pada file readme untuk menjelaskan penggunaan API Google reCAPTCHA sesuai pedoman.
* CATATAN PENTING: Karena perubahan prefix internal yang signifikan, semua pengaturan plugin akan direset setelah melakukan update ke versi ini. Harap lakukan konfigurasi ulang atau pulihkan dari cadangan.